### PR TITLE
Fix bash syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Try this `rad` one-liner:
 
 ```shell
 $ # Press `Ctrl+Z` and use the `fg` command as needed
-$ rad docs serve --all --host=0.0.0.0 &; rad watch
+$ rad docs serve --all --host=0.0.0.0 & rad watch
 ```
 
 Then, visit [`localhost:7000`](http://localhost:7000/), or open


### PR DESCRIPTION
```bash
$ echo 1 &; echo 2
bash: syntax error near unexpected token `;'
$ echo 1 & echo 2
[1] 32866
2
1
```